### PR TITLE
Add stats to pokemon details page

### DIFF
--- a/src/pages/pokemon/details.js
+++ b/src/pages/pokemon/details.js
@@ -14,6 +14,7 @@ import {
     PokeDetailsName,
     PokeDetailsSprites, 
     PokeDetailTypes,
+    PokeDetailsStats,
     PokeDetailsLeftImage,
     PokeDetailTitleSection,
     PokeDetailsBallImg,
@@ -29,9 +30,13 @@ const PokemonDetails = () => {
 
     const history = useHistory();
     const { slug } = useParams();
-    const { catchPokemon, pokemonDetailArtwork, setPokemonDetailArtwork, setPokemonDetailData } = useContext(PokeContext)
+    const { catchPokemon, pokemonDetailArtwork, setPokemonDetailArtwork } = useContext(PokeContext)
 
     const [pokemonData, setPokemonData] = useState({
+        isLoading: true,
+        data: null,
+    });
+    const [pokemonDetailData, setPokemonDetailData] = useState({
         isLoading: true,
         data: null,
     });
@@ -66,9 +71,7 @@ const PokemonDetails = () => {
                         artWork: data.sprites.other,
                     });
                     setPokemonDetailData({
-                        data: {
-                            name: data.name,
-                        }
+                        data: data
                     });
                 }
             );
@@ -122,6 +125,14 @@ const PokemonDetails = () => {
     const GenerateMoves = (moves) => {
         const res = moves.map((list) => (
             <PokeDetailsAbilitiesMoves key={list.move.name} type="move">{list.move.name}</PokeDetailsAbilitiesMoves>
+        ));
+
+        return res;
+    };
+
+    const GenerateStats = (stats) => {
+        const res = stats.map((list) => (
+            <PokeDetailsStats key={list.stat.name}>{list.stat.name}: {list.base_stat}</PokeDetailsStats>
         ));
 
         return res;
@@ -205,6 +216,18 @@ const PokemonDetails = () => {
                     <PokeDetailsBoxStatus>
                         {
                             !pokemonData.isLoading && GenerateMoves(pokemonData.data.moves)
+                        }
+                        {
+                            pokemonData.isLoading && <Skeleton height="20px" />
+                        }
+                    </PokeDetailsBoxStatus>
+                    <PokeDetailTitleSection>Stats</PokeDetailTitleSection>
+                    <PokeDetailsBoxStatus>
+                        {
+                            !pokemonDetailData.isLoading &&
+                                <PokeDetailsBoxStatusUl>
+                                    { GenerateStats(pokemonDetailData.data.stats) }
+                                </PokeDetailsBoxStatusUl>
                         }
                         {
                             pokemonData.isLoading && <Skeleton height="20px" />

--- a/src/utilities/styledComponent.js
+++ b/src/utilities/styledComponent.js
@@ -376,6 +376,10 @@ export const PokeDetailsAbilitiesMoves = styled.span`
     display: inline-block;
 `;
 
+export const PokeDetailsStats = styled.p`
+    text-transform: uppercase;
+`;
+
 export const PokeDetailsLeftImage = styled.div`
     display: flex;
     align-self: flex-start;


### PR DESCRIPTION
Resolves #13

Added status to the details page.
![image](https://user-images.githubusercontent.com/2524168/137613462-9d76ddea-9e0b-481f-9041-1908d48ad4b0.png)


At first I tried to get the stats from `pokemonData`, but the names all seem to be `hp`, I think it's a bug in the API.
So I'm getting the stats from `pokemonDetailData`.

![image](https://user-images.githubusercontent.com/2524168/137613468-941267bf-9860-4d53-a37d-5e6350beb74d.png)
