### PR TITLE
Add Evolution Data to Details Page

### DIFF
--- a/src/pages/pokemon/details.js
+++ b/src/pages/pokemon/details.js
@@ -18,6 +18,8 @@ import {
     PokeDetailTitleSection,
     PokeDetailsBallImg,
     PokeDetailsActions,
+    PokeDetailsEvolutions,
+	PokeDetailsEvolutionsCurrent,
 } from 'utilities/styledComponent';
 import { Skeleton, Stack } from "@chakra-ui/react"
 import { PokeContext } from 'utilities/context';
@@ -136,6 +138,25 @@ const PokemonDetails = () => {
         </PokeDetailsSprites>
     );
 
+	const GenerateEvolutions = evolutions => {
+		const isCurrentEvo = evolution =>
+			evolution === PokeCommonData?.data.pokemon.name;
+
+		const evos = evolutions.map(evo => {
+			const isCurrent = isCurrentEvo(evo);
+			return isCurrent ? (
+				<PokeDetailsEvolutionsCurrent>
+					{evo.toUpperCase()}
+				</PokeDetailsEvolutionsCurrent>
+			) : (
+				<PokeDetailsEvolutions>
+					{evo.toUpperCase()}
+				</PokeDetailsEvolutions>
+			);
+		});
+		return evos;
+	};
+
     return (
         <PokeDetailsContainer>
             <PokeDetailsLeftImage>
@@ -201,6 +222,20 @@ const PokemonDetails = () => {
                             pokemonData.isLoading && <Skeleton height="20px" />
                         }
                     </PokeDetailsBoxStatus>
+                    <PokeDetailTitleSection>Evolution Chain</PokeDetailTitleSection>
+                        <PokeDetailsBoxStatus flex>
+                            {!pokemonEvolutionData.isLoading &&
+                                GenerateEvolutions([
+                                    pokemonEvolutionData.data.species.name,
+                                    pokemonEvolutionData.data.evolves_to[0].species
+                                        .name,
+                                    pokemonEvolutionData.data.evolves_to[0]
+                                        .evolves_to[0].species.name,
+                                ])}
+                            {pokemonEvolutionData.isLoading && (
+                                <Skeleton height='20px' />
+                            )}
+                        </PokeDetailsBoxStatus>
                     <PokeDetailTitleSection>Moves</PokeDetailTitleSection>
                     <PokeDetailsBoxStatus>
                         {

--- a/src/utilities/styledComponent.js
+++ b/src/utilities/styledComponent.js
@@ -384,6 +384,24 @@ export const PokeDetailsLeftImage = styled.div`
     width: 100%;
 `;
 
+export const PokeDetailsEvolutions = styled.span`
+	display: flex;
+	flex-direction: column;
+	margin: 0 auto;
+	text-align: center;
+`;
+
+export const PokeDetailsEvolutionsCurrent = styled.span`
+	font-weight: 600;
+	transform: skewX(-10deg);
+	background-color: #f9c921;
+	color: #220a3d;
+	padding: 0px 10px;
+	border: 1px solid #19072d;
+	border-radius: 4px;
+	margin: 0 auto;
+`;
+
 export const PokeDetailsCatch = styled.div`
     color: #ffffff;
     font-weight: 700;


### PR DESCRIPTION
## Evolution Data to Details Page- #3 

Added the evolution chain to the details page. The current evolution that is on the page will be highlighted.

![mypokemondex](https://user-images.githubusercontent.com/67440557/137728426-1cf81043-297e-4291-bc7b-f0107ca8e80a.png)


